### PR TITLE
Update gravatar.html -- repeating template compatiblity

### DIFF
--- a/src/gravatar.html
+++ b/src/gravatar.html
@@ -29,9 +29,18 @@
 	};
 
 	Polymer('gravatar-image', {
-		created: function() {
+		_updateGravatarElements: function() {
 			this.$.username.href = Gravatar.profileURL(this);
 			this.$.username_image.src = Gravatar.imageURL(this.username, this.size, this.hash);
+		},
+		usernameChanged: function() {
+			this._updateGravatarElements();
+		},
+		hashChanged: function() {
+			this._updateGravatarElements();
+		},
+		sizeChanged: function() {
+			this._updateGravatarElements();
 		},
 		hash: '',
 		username: 'someemail@example.com',


### PR DESCRIPTION
The current version of gravatar-image will only use the username or hash defined in the element's prototype if a gravatar-image element is being modified after creation (i.e. in a repeating template).These changes will allow you to modify the size, username, and hash inside a repeating template and will yield the results that you are looking for in this context.
